### PR TITLE
Fix MediaPipe import - use HuggingFace compatible imports only

### DIFF
--- a/jewelry_engine.py
+++ b/jewelry_engine.py
@@ -32,32 +32,22 @@ try:
 except ImportError as e:
     logger.warning(f"cvzone not available: {e}. Install with: pip install cvzone")
 
-# MediaPipe imports with HuggingFace Spaces compatibility
-# Try standard import first, then fallback to mediapipe.python.solutions
+# MediaPipe imports - use HuggingFace Spaces compatible import method
+# Note: Do NOT use 'import mediapipe as mp' then 'mp.solutions.*' as it fails on HuggingFace
 MEDIAPIPE_AVAILABLE = False
 mp_face_mesh = None
 mp_drawing = None
 
 try:
-    # Standard import (works on most systems)
-    import mediapipe as mp
-    mp_face_mesh = mp.solutions.face_mesh
-    mp_drawing = mp.solutions.drawing_utils
+    # HuggingFace Spaces compatible import (works on all environments)
+    from mediapipe.python.solutions import face_mesh as mp_face_mesh
+    from mediapipe.python.solutions import drawing_utils as mp_drawing
     MEDIAPIPE_AVAILABLE = True
-    logger.info("MediaPipe loaded with standard import")
-except Exception:
-    # Fallback for HuggingFace Spaces or other environments
-    try:
-        from mediapipe.python.solutions import face_mesh as mp_face_mesh_module
-        from mediapipe.python.solutions import drawing_utils as mp_drawing_module
-        mp_face_mesh = mp_face_mesh_module
-        mp_drawing = mp_drawing_module
-        MEDIAPIPE_AVAILABLE = True
-        logger.info("MediaPipe loaded with HuggingFace compatible import (mediapipe.python.solutions)")
-    except Exception as e:
-        logger.warning(f"MediaPipe not available: {e}. Install with: pip install mediapipe")
-        mp_face_mesh = None
-        mp_drawing = None
+    logger.info("MediaPipe loaded successfully (mediapipe.python.solutions)")
+except Exception as e:
+    logger.warning(f"MediaPipe not available: {e}. Install with: pip install mediapipe")
+    mp_face_mesh = None
+    mp_drawing = None
 
 
 class JewelryEngine:


### PR DESCRIPTION
Remove the standard 'import mediapipe as mp' / 'mp.solutions.*' import pattern that fails on HuggingFace Spaces. Now using only the compatible 'from mediapipe.python.solutions import face_mesh, drawing_utils' method.