### PR TITLE
Enable destination parameter in training job creation

### DIFF
--- a/scripts/train_replicate.py
+++ b/scripts/train_replicate.py
@@ -70,8 +70,7 @@ def create_training_job():
                 "caption_prefix": DEFAULT_CAPTION_PREFIX,
                 "max_train_steps": max_steps,
             },
-            #             destination=destination
-            
+            destination=destination,
         )
 
         print(f"Training job created successfully!")


### PR DESCRIPTION
## Summary
Uncommented and enabled the `destination` parameter in the training job creation function to allow specifying where training outputs should be stored.

## Changes
- Uncommented the `destination=destination` parameter in the `create_training_job()` function
- Removed unnecessary commented-out code and extra whitespace for cleaner formatting

## Details
The `destination` parameter was previously commented out, preventing users from specifying custom output destinations for training jobs. This change activates that functionality, allowing the destination to be properly passed to the training job configuration.

https://claude.ai/code/session_01M8TrDhvbSt2iSZsn4H2pVT